### PR TITLE
Fail on improperly formatted checksum lines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,8 +46,8 @@ RUN gpg --import /tmp/pubkeys/*.asc
 RUN echo "E7ADD9914E260E8B35DFB50665FDE935573ACDA6:6:"|gpg --import-ownertrust
 
 # verify downloaded files
-RUN gpg --verify *.tar.gz.asc *.tar.gz
-RUN gpg --verify *.sha256.txt.asc *.sha256.txt
+RUN gpg --batch --verify *.tar.gz.asc *.tar.gz
+RUN gpg --batch --verify *.sha256.txt.asc *.sha256.txt
 RUN sha256sum --strict -c *.sha256.txt
 RUN mkdir -p /tmp/threema \
     && tar -xzf *.tar.gz --strip-components 1 -C /tmp/threema

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN echo "E7ADD9914E260E8B35DFB50665FDE935573ACDA6:6:"|gpg --import-ownertrust
 # verify downloaded files
 RUN gpg --verify *.tar.gz.asc *.tar.gz
 RUN gpg --verify *.sha256.txt.asc *.sha256.txt
-RUN sha256sum -c *.sha256.txt
+RUN sha256sum --strict -c *.sha256.txt
 RUN mkdir -p /tmp/threema \
     && tar -xzf *.tar.gz --strip-components 1 -C /tmp/threema
 WORKDIR /app


### PR DESCRIPTION
Adds --strict for checksum verification to prevent a potential vulnerability when the checksum is improperly formatted and.
As per https://github.com/docker-library/official-images#image-build